### PR TITLE
Add component deregistration method.

### DIFF
--- a/src/components/index.lua
+++ b/src/components/index.lua
@@ -104,6 +104,13 @@ function Slab.RegisterComponent(key, component)
     registry[key] = Slab.Component(component)
 end
 
+---Deregister a component
+---@param key string
+---@param component Component
+function Slab.DeregisterComponent(key)
+  registry[key] = nil
+end
+
 ---@alias ComponentConstructed ComponentConstructor
 
 ---Construct a component.


### PR DESCRIPTION
I'm worried about some edge cases with this, but it *should* consistently occur prior to any components being used. I have noticed no issues while I was working on some other components. Have reloaded in combat, have not tested in raid.

If a component has been used before it is nil'd, it may break everything kinda horrendously.

At the risk of stating the obvious and documentation, this would be bad to use in the core addon, and you need to make sure that your component(s) you are deregistering are already loaded.